### PR TITLE
fixed footer link

### DIFF
--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -25,7 +25,9 @@ export default function Footer() {
 
           <a
             class="inline-flex items-center rounded border p-2 bg-gray-50"
-            href="/download"
+            href="https://github.com/hekors/hacker-profiles"
+            target="_blank"
+            rel="noreferrer"
           >
             <span class="text-sm font-medium mx-2"> Contribute </span>
 


### PR DESCRIPTION
**Description**

- Fixed the link on line 28 of the `/src/components/footer/index.jsx`
- Added `target="_blank"` and `rel="noreferrer"` below the link.

**Related issue(s)**
Resolves https://github.com/hekors/hacker-profiles/issues/14